### PR TITLE
add jaopca mod for ore processing compat.

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -1999,6 +1999,11 @@ hash = "f5e3281c535e0496e47c599773da24ad7513904701dff2114f584198588c47a3"
 metafile = true
 
 [[files]]
+file = "mods/jaopca.pw.toml"
+hash = "ca228304f1ea9a7d4cbc76bc28fc5625c94dfdf10fcdfdfef4f52efc8bacaca3"
+metafile = true
+
+[[files]]
 file = "mods/jei.pw.toml"
 hash = "52afe64a215ec7a20a2424de639020369e5d25fad69ede02a700edde08dd81db"
 metafile = true

--- a/index.toml
+++ b/index.toml
@@ -2394,6 +2394,11 @@ hash = "ec19ef2adf6994632d4fc25b6ed1a2ad1a0c996aa364b78d5aba1bd7b5d74f2e"
 metafile = true
 
 [[files]]
+file = "mods/simply-light.pw.toml"
+hash = "ea9c81ef618e5b7189dafd23aae5fd615348486261111697be25023df5f6fdb5"
+metafile = true
+
+[[files]]
 file = "mods/smooth-boot-reloaded.pw.toml"
 hash = "49a62dc782f18f414f4dd5fd08a10a31c8698a87404ed12b7a847b6ac474c2e4"
 metafile = true

--- a/mods/jaopca.pw.toml
+++ b/mods/jaopca.pw.toml
@@ -1,0 +1,13 @@
+name = "JAOPCA"
+filename = "JAOPCA-1.19.2-4.2.7.14.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "93b5c7903728f6ec85c85649c5395c284642fcdb"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4528303
+project-id = 266936

--- a/mods/simply-light.pw.toml
+++ b/mods/simply-light.pw.toml
@@ -1,0 +1,13 @@
+name = "Simply Light"
+filename = "simplylight-1.19.2-1.4.5-build.42.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "c0235abb2bf0257fa139dd641cb98615c1750a5c"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4016401
+project-id = 300331

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "8f7c95e26b587d10b94b75f7938d66e86e328baf80de5c051b2dda5ed95e8838"
+hash = "7a8b990cf7dc753ab96315663253447beed68e6b2e42338658136e724c7b93be"
 
 [versions]
 forge = "43.2.21"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "7a8b990cf7dc753ab96315663253447beed68e6b2e42338658136e724c7b93be"
+hash = "086a68b108798fa1835e073bb8c704b76f637756a3089d58224758bd68855599"
 
 [versions]
 forge = "43.2.21"


### PR DESCRIPTION
adds the [jaopca mod](https://www.curseforge.com/minecraft/mc-mods/jaopca) for ore processing compatibility between various mods including Mekanism and Thermal Series allowing all the crushing and pulverizing to our heart's content.